### PR TITLE
Mark Poezio as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "end-of-life": "This application is no longer maintained."
+}


### PR DESCRIPTION
This application relies on an old runtime that was marked as end-of-life (EOL) two years ago.

https://github.com/flathub/io.poez.Poezio/issues/4